### PR TITLE
add ONT isoform assignment workflow

### DIFF
--- a/bin/assign_ONT_reads_to_isoforms.py
+++ b/bin/assign_ONT_reads_to_isoforms.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+
+import warnings
+warnings.simplefilter('ignore')
+import sys
+import os
+import pandas as pd
+import numpy as np
+import HTSeq
+from argparse import ArgumentParser, RawTextHelpFormatter
+
+def main():
+    parser = ArgumentParser(description="ONT Isoform Management", formatter_class=RawTextHelpFormatter)
+    parser.add_argument("--mode", dest="mode", choices=['enrich', 'assign'], required=True, 
+                        help="enrich: Create master isoforms from all BAMs\nassign: Map alignments to the enriched GTF")
+    parser.add_argument("--input_bam_files", dest="input_bam_files", required=True)
+    parser.add_argument("--input_gtf_file", dest="input_gtf_file", required=True)
+    parser.add_argument("--output_prefix", dest="output_prefix", required=True)
+    parser.add_argument("--ThreePrimeEnd_clustering_distance", type=int, default=25)
+    parser.add_argument("--gtf_skip_rows", type=int, default=5)
+
+    args = parser.parse_args()
+
+    # Determine BAM files to process
+    if args.mode == 'enrich' and os.path.isfile(args.input_bam_files):
+        with open(args.input_bam_files, 'r') as f:
+            bam_paths = [line.strip() for line in f if line.strip()]
+    else:
+        bam_paths = [args.input_bam_files]
+
+    # 1. Parse Alignments
+    read_coords = []
+    for bam_path in bam_paths:
+        # Using SAM_Reader as it handles both SAM/BAM correctly in HTSeq and matches the original script
+        bam_file = HTSeq.SAM_Reader(bam_path)
+        for algn in bam_file:
+            if not algn.aligned or algn.supplementary:
+                continue
+            
+            introns_list = []
+            cigar_string = ""
+            
+            # Explicitly parse the CIGAR string to find splice junctions ('N')
+            if algn.cigar is not None:
+                for cigar_elem in algn.cigar:
+                    cigar_string += f"{cigar_elem.size}{cigar_elem.type}"
+                    if cigar_elem.type == 'N': 
+                        reference_region = cigar_elem.ref_iv
+                        # 1-based end coordinate matching original script logic
+                        introns_list.append((reference_region.start, reference_region.end + 1))
+            
+            # Convert to string so pandas can group by it later
+            introns_str = str(tuple(introns_list))
+            
+            # Unique ID: read_id + region + CIGAR string
+            uid = f"{algn.read.name}_{algn.iv.chrom}_{algn.iv.start}_{algn.iv.end}_{cigar_string}"
+            
+            read_coords.append({
+                'read_id': algn.read.name,
+                'alignment_id': uid,
+                'chrom': algn.iv.chrom,
+                'start': algn.iv.start,
+                'end': algn.iv.end,
+                'strand': algn.iv.strand,
+                'introns': introns_str
+            })
+    
+    read_df = pd.DataFrame(read_coords)
+
+    # Safety check for empty dataframes
+    if read_df.empty:
+        print("[WARNING] No valid alignments found in the provided BAM file(s).")
+        sys.exit(0)
+
+    # 2. Process based on Mode
+    if args.mode == 'enrich':
+        # Group identical read structures into unique master isoforms
+        isoforms_df = read_df.groupby(['chrom', 'strand', 'introns']).agg({'start': 'min', 'end': 'max'}).reset_index()
+        isoforms_df['transcript_id'] = [f"isoform_{i}" for i in range(len(isoforms_df))]
+        
+        # Save Enriched Transcriptome
+        out_path = f"{args.output_prefix}_enriched.tsv"
+        isoforms_df.to_csv(out_path, sep='\t', index=False)
+        print(f"[SUCCESS] Enriched transcriptome saved to {out_path} with {len(isoforms_df)} unique isoforms.")
+
+    elif args.mode == 'assign':
+        # Load the Master Map created in 'enrich' mode
+        master_map = pd.read_csv(args.input_gtf_file, sep='\t')
+        
+        # Map reads to Master Map IDs
+        assignments = pd.merge(read_df, master_map, on=['chrom', 'strand', 'introns'], how='left', suffixes=('', '_ref'))
+        
+        # Format output as requested: Associate every alignment with ONE transcript_id
+        final_cols = ['alignment_id', 'read_id', 'transcript_id', 'chrom', 'start', 'end', 'strand']
+        out_path = f"{args.output_prefix}_assignments.tsv"
+        
+        # Handle unassigned reads
+        unassigned = assignments[assignments['transcript_id'].isna()]
+        if not unassigned.empty:
+            unassigned[final_cols].to_csv(f"{args.output_prefix}_unassigned.tsv", sep='\t', index=False)
+            
+        assigned = assignments.dropna(subset=['transcript_id'])
+        if not assigned.empty:
+            assigned[final_cols].to_csv(out_path, sep='\t', index=False)
+        else:
+            # Output an empty file with headers if no assignments match
+            pd.DataFrame(columns=final_cols).to_csv(out_path, sep='\t', index=False)
+            
+        print(f"[SUCCESS] Assigned: {len(assigned)} | Unassigned: {len(unassigned)}. Saved to {out_path}")
+
+if __name__ == "__main__":
+    main()

--- a/main.nf
+++ b/main.nf
@@ -4,12 +4,13 @@ nextflow.enable.dsl = 2
 /*
 ========================================================================================
     NANAFLOWZ MAIN PIPELINE
-    Optimized for consolidated subsampling and signal visualization.
+    Optimized for consolidated subsampling, signal visualization, and isoform analysis.
 ========================================================================================
 */
 
 // Check if TSV is provided
 if( !params.tsv ) { exit 1, "Please provide the input TSV file with --tsv" }
+if( !params.reference_gtf ) { exit 1, "Please provide the reference GTF file with --reference_gtf" }
 
 // Default base directory for QC plots
 params.qc_base_dir = "${params.outdir}/QC_plots/raw_signal_annotation"
@@ -28,11 +29,31 @@ workflow {
     merge_input_ch = dorado_basecall.out.bam.groupTuple()
     merge_bams(merge_input_ch)
 
+    // ==============================================================================
+    // ISOFORM ANALYSIS
+    // ==============================================================================
+
+    // A. Collect all merged BAM files to build the master enriched transcriptome
+    all_bams_ch = merge_bams.out.bam.map { it[1] }.collect()
+    
+    transcriptome_annotation_enrichment(
+        all_bams_ch, 
+        params.reference_gtf
+    )
+
+    // B. Assign individual alignments for each sample to the enriched transcriptome
+    read_to_transcript_assignment(
+        merge_bams.out.bam, 
+        transcriptome_annotation_enrichment.out.gtf
+    )
+
+    // ==============================================================================
+
     // 4. Selection: Pick the random Read IDs to investigate
     extract_read_ids(merge_bams.out.bam)
 
-    // We take all original POD5 paths and group them by sample_id
-    // This allows one process to search all 1,400 files at once.
+    // 5. We take all original POD5 paths and group them by sample_id
+    // This allows one process to search all files at once.
     all_pod5s_per_sample = samples_ch.map { id, pod5 -> [id, pod5] }.groupTuple()
     
     filter_input_ch = extract_read_ids.out.ids_file.join(all_pod5s_per_sample)
@@ -98,6 +119,54 @@ process merge_bams {
     """
 }
 
+process transcriptome_annotation_enrichment {
+    label 'process_high'
+    publishDir "${params.outdir}/transcriptome", mode: 'copy'
+
+    input:
+    path bams
+    path reference_gtf
+
+    output:
+    path "master_enriched.tsv", emit: gtf
+
+    script:
+    """
+    # Create a manifest file containing the paths of all staged BAM files
+    ls *.bam > bam_list.txt
+    
+    assign_ONT_reads_to_isoforms.py \\
+        --mode enrich \\
+        --input_bam_files bam_list.txt \\
+        --input_gtf_file ${reference_gtf} \\
+        --output_prefix master
+    """
+}
+
+process read_to_transcript_assignment {
+    tag "${sample_id}"
+    publishDir "${params.outdir}/assignments", mode: 'copy'
+
+    input:
+    tuple val(sample_id), path(bam)
+    path enriched_gtf
+
+    output:
+    tuple val(sample_id), path("${sample_id}_assignments.tsv.gz"), emit: tsv
+    path "${sample_id}_unassigned.tsv", optional: true
+
+    script:
+    """
+    assign_ONT_reads_to_isoforms.py \\
+        --mode assign \\
+        --input_bam_files ${bam} \\
+        --input_gtf_file ${enriched_gtf} \\
+        --output_prefix ${sample_id}
+    
+    gzip ${sample_id}_assignments.tsv
+    """
+}
+
 process extract_read_ids {
     tag "${sample_id}"
     input:
@@ -124,7 +193,7 @@ process filter_pod5_combined {
 
     script:
     """
-    # Scans all 1,400 chunks in one pass to find the target IDs
+    # Scans all chunks in one pass to find the target IDs
     pod5 filter ${all_pod5_chunks} \\
         --output ${sample_id}.subset.pod5 \\
         --ids ${read_ids_txt} \\

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,7 +5,8 @@
     Configuration file for the Nanoflowz pipeline.
     
     This config is optimized for NVIDIA GPU nodes (e.g., A100).
-    It handles two-pass basecalling (Dorado) and signal visualization (Seaborn).
+    It handles two-pass basecalling (Dorado), isoform assignment, 
+    and signal visualization (Seaborn).
 ========================================================================================
 */
 
@@ -33,11 +34,13 @@ params {
     //  BIOLOGICAL REFERENCES & MODELS
     // ---------------------------------------------------------------------------------
     // model: The Dorado basecalling model (SUP is recommended for signal accuracy)
-    model      = "${myHome}/nanoflowz/rna004_130bps_sup@v5.1.0"
+    model         = "${myHome}/nanoflowz/dna_r10.4.1_e8.2_400bps_sup@v5.2.0"
     // polyA: Custom configuration file for Dorado's poly-A tail estimation
-    polyA      = "${myHome}/materials/polya_config.toml"
+    polyA         = "${myHome}/materials/polya_config.toml"
     // ref: Genome FASTA used for alignment during basecalling
-    ref        = "${myHome}/nanoflowz/GRCm38.primary_assembly.genome.fa"
+    ref           = "/scicore/home/zavolan/GROUP/Genomes/homo_sapiens/Homo_sapiens.GRCh38.dna.primary_assembly.fa"
+    // reference_gtf: Pre-existing annotation file used for isoform enrichment and assignment
+    reference_gtf = "/scicore/home/zavolan/GROUP/Genomes/homo_sapiens/hg38_v42/gencode.v42.annotation.gtf"
 
     // ---------------------------------------------------------------------------------
     //  PIPELINE SETTINGS & VISUALIZATION
@@ -84,6 +87,30 @@ process {
         time           = '29m'
         // --gres=gpu:1 is required to request the physical GPU hardware on SLURM
         clusterOptions = '--gres=gpu:1 --qos=a100-1day'
+    }
+
+    // ---------------------------------------------------------------------------------
+    //  ISOFORM ANALYSIS RESOURCES
+    // ---------------------------------------------------------------------------------
+    withName: transcriptome_annotation_enrichment {
+        cpus          = 2
+        // Dynamically increase memory based on the attempt number
+        memory        = { 128.GB * task.attempt }
+        time          = '2h'
+        
+        // Catch OOM errors (137, sometimes 104 or 140 in SLURM) and retry
+        errorStrategy = { task.exitStatus in [137, 104, 140] ? 'retry' : 'terminate' }
+        maxRetries    = 2
+    }
+
+    withName: read_to_transcript_assignment {
+        cpus          = 2
+        // Start at 32 GB, scale to 64 GB, then 96 GB if it keeps getting killed
+        memory        = { 32.GB * task.attempt } 
+        time          = { 2.h * task.attempt } // Scaling time is a good idea too
+        
+        errorStrategy = { task.exitStatus in [137, 104, 140] ? 'retry' : 'terminate' }
+        maxRetries    = 2
     }
 
     // ---------------------------------------------------------------------------------


### PR DESCRIPTION
Introduce a dedicated ONT isoform enrichment and assignment step into the Nanoflowz pipeline.

Add a new helper script `assign_ONT_reads_to_isoforms.py` that parses long-read alignments, explicitly captures intron structures from CIGAR strings, and aggregates alignments into master isoforms. The script supports two modes: (1) `enrich`, which builds an enriched transcriptome by collapsing identical exon–intron structures across BAM files, and (2) `assign`, which maps individual alignments back to these enriched isoforms, emitting separate tables for assigned and unassigned reads.

Extend `main.nf` with an isoform analysis sub-workflow that first collects all merged BAMs to construct the master enriched transcriptome, then assigns per-sample alignments to that reference. The new processes `transcriptome_annotation_enrichment` and `read_to_transcript_assignment` are wired into the existing merge outputs and produce per-sample assignment tables (plus optional unassigned reports) while keeping downstream read ID extraction and pod5 filtering intact.

Update `nextflow.config` to document and configure the isoform analysis resources, including CPU, memory, and retry/error strategies tailored for potentially large transcriptome jobs. Refresh the default Dorado model and reference genome paths, and introduce a `reference_gtf` parameter to drive the enrichment and assignment steps, ensuring the pipeline is ready for isoform-level analyses on the configured human reference.

Addresses Issue #17.