### PR TITLE
pipeline: propagate pt/qs tags in ONT isoform assignment; bump Dorado

### DIFF
--- a/bin/assign_ONT_reads_to_isoforms.py
+++ b/bin/assign_ONT_reads_to_isoforms.py
@@ -7,12 +7,25 @@ import os
 import pandas as pd
 import numpy as np
 import HTSeq
+import ast
+import gzip
 from argparse import ArgumentParser, RawTextHelpFormatter
+
+def get_introns_from_exons(exons):
+    """Converts a list of (start, end) exons to an intron string."""
+    if len(exons) <= 1:
+        return "()"
+    exons = sorted(exons)
+    introns = []
+    for i in range(len(exons) - 1):
+        # Intron: end of current exon to start of next exon
+        introns.append((exons[i][1], exons[i+1][0]))
+    return str(tuple(introns))
 
 def main():
     parser = ArgumentParser(description="ONT Isoform Management", formatter_class=RawTextHelpFormatter)
     parser.add_argument("--mode", dest="mode", choices=['enrich', 'assign'], required=True, 
-                        help="enrich: Create master isoforms from all BAMs\nassign: Map alignments to the enriched GTF")
+                        help="enrich: Create master isoforms from all BAMs + Reference\nassign: Map alignments to the enriched GTF")
     parser.add_argument("--input_bam_files", dest="input_bam_files", required=True)
     parser.add_argument("--input_gtf_file", dest="input_gtf_file", required=True)
     parser.add_argument("--output_prefix", dest="output_prefix", required=True)
@@ -22,90 +35,191 @@ def main():
     args = parser.parse_args()
 
     # Determine BAM files to process
-    if args.mode == 'enrich' and os.path.isfile(args.input_bam_files):
+    if os.path.isfile(args.input_bam_files) and not args.input_bam_files.endswith(".bam"):
         with open(args.input_bam_files, 'r') as f:
             bam_paths = [line.strip() for line in f if line.strip()]
     else:
         bam_paths = [args.input_bam_files]
 
-    # 1. Parse Alignments
-    read_coords = []
-    algn_counter = 0 
-
-    for bam_path in bam_paths:
-        bam_file = HTSeq.SAM_Reader(bam_path)
-        for algn in bam_file:
-            if not algn.aligned or algn.supplementary:
-                continue
-            
-            # Extract optional tags pt and qs
-            try:
-                pt_val = algn.optional_field("pt")
-            except (KeyError, AttributeError):
-                pt_val = None
-                
-            try:
-                qs_val = algn.optional_field("qs")
-            except (KeyError, AttributeError):
-                qs_val = None
-            
-            introns_list = []
-            cigar_string = ""
-            
-            if algn.cigar is not None:
-                for cigar_elem in algn.cigar:
-                    cigar_string += f"{cigar_elem.size}{cigar_elem.type}"
-                    if cigar_elem.type == 'N': 
-                        reference_region = cigar_elem.ref_iv
-                        introns_list.append((reference_region.start, reference_region.end + 1))
-            
-            introns_str = str(tuple(introns_list))
-            
-            read_coords.append({
-                'alignment_id': algn_counter, 
-                'read_id': algn.read.name,
-                'chrom': algn.iv.chrom,
-                'start': algn.iv.start,
-                'end': algn.iv.end,
-                'strand': algn.iv.strand,
-                'introns': introns_str,
-                'pt': pt_val,
-                'qs': qs_val
-            })
-            algn_counter += 1
-    
-    read_df = pd.DataFrame(read_coords)
-
-    if read_df.empty:
-        print("[WARNING] No valid alignments found in the provided BAM file(s).")
-        sys.exit(0)
-
-    # 2. Process based on Mode
+    # --- MODE: ENRICH ---
     if args.mode == 'enrich':
-        isoforms_df = read_df.groupby(['chrom', 'strand', 'introns']).agg({'start': 'min', 'end': 'max'}).reset_index()
-        isoforms_df['transcript_id'] = [f"isoform_{i}" for i in range(len(isoforms_df))]
+        # 1. Extract Reference Transcriptome Structure
+        print(f"[INFO] Parsing Reference GTF: {args.input_gtf_file}")
+        gtf_cols = ['chrom', 'source', 'feature', 'start', 'end', 'score', 'strand', 'frame', 'attribute']
+        ref_gtf_full = pd.read_csv(args.input_gtf_file, sep='\t', comment='#', header=None, names=gtf_cols, skiprows=args.gtf_skip_rows)
         
-        out_path = f"{args.output_prefix}_enriched.tsv"
-        isoforms_df.to_csv(out_path, sep='\t', index=False)
-        print(f"[SUCCESS] Enriched transcriptome saved to {out_path} with {len(isoforms_df)} unique isoforms.")
+        # We need exons to build intron strings for the reference
+        ref_exons = ref_gtf_full[ref_gtf_full['feature'] == 'exon'].copy()
+        ref_exons['transcript_id'] = ref_exons['attribute'].str.extract('transcript_id "([^"]+)"')
+        
+        ref_data = []
+        for tid, group in ref_exons.groupby('transcript_id'):
+            chrom = group['chrom'].iloc[0]
+            strand = group['strand'].iloc[0]
+            # Convert 1-based GTF to 0-based for internal logic consistency
+            exons = sorted(list(zip(group['start'] - 1, group['end'])))
+            introns_str = get_introns_from_exons(exons)
+            
+            t_start = group['start'].min() - 1
+            t_end = group['end'].max()
+            three_prime = t_end if strand == "+" else t_start
+            
+            ref_data.append({
+                'transcript_id': tid, 'chrom': chrom, 'strand': strand,
+                'start': t_start, 'end': t_end, 'introns': introns_str,
+                'three_prime': three_prime, 'is_ref': True
+            })
+        ref_df = pd.DataFrame(ref_data)
 
+        # 2. Extract Observed Transcriptome from BAMs
+        print("[INFO] Parsing BAM Alignments...")
+        read_coords = []
+        algn_counter = 0 
+        for bam_path in bam_paths:
+            bam_file = HTSeq.SAM_Reader(bam_path)
+            for algn in bam_file:
+                if not algn.aligned or algn.supplementary:
+                    continue
+                
+                introns_list = []
+                if algn.cigar is not None:
+                    for cigar_elem in algn.cigar:
+                        if cigar_elem.type == 'N': 
+                            reference_region = cigar_elem.ref_iv
+                            introns_list.append((reference_region.start, reference_region.end + 1))
+                
+                three_prime = algn.iv.end if algn.iv.strand == "+" else algn.iv.start
+                read_coords.append({
+                    'transcript_id': None, 'chrom': algn.iv.chrom, 'strand': algn.iv.strand,
+                    'start': algn.iv.start, 'end': algn.iv.end, 'introns': str(tuple(introns_list)),
+                    'three_prime': three_prime, 'is_ref': False
+                })
+                algn_counter += 1
+        
+        read_df = pd.DataFrame(read_coords)
+
+        # 3. Merge and Cluster 3' Ends
+        print(f"[INFO] Clustering 3' ends (distance: {args.ThreePrimeEnd_clustering_distance}bp)...")
+        combined_df = pd.concat([ref_df, read_df], ignore_index=True)
+        
+        # Sort and calculate clusters based on proximity
+        all_ends = combined_df[['chrom', 'strand', 'three_prime']].drop_duplicates().sort_values(['chrom', 'strand', 'three_prime'])
+        all_ends['diff'] = all_ends.groupby(['chrom', 'strand'])['three_prime'].diff()
+        all_ends['new_cluster'] = (all_ends['diff'] > args.ThreePrimeEnd_clustering_distance).astype(int)
+        all_ends['cluster_id'] = all_ends.groupby(['chrom', 'strand'])['new_cluster'].cumsum()
+        
+        combined_df = pd.merge(combined_df, all_ends[['chrom', 'strand', 'three_prime', 'cluster_id']], on=['chrom', 'strand', 'three_prime'])
+
+        # 4. Final Enrichment Logic (Collapse)
+        enriched_isoforms = []
+        # Group by intron structure and 3' cluster
+        for (chrom, strand, introns, cluster_id), group in combined_df.groupby(['chrom', 'strand', 'introns', 'cluster_id']):
+            ref_subset = group[group['is_ref'] == True]
+            
+            if not ref_subset.empty:
+                # Use reference metadata if it exists in this structural group
+                t_id = ref_subset['transcript_id'].iloc[0]
+                t_start = ref_subset['start'].min()
+                t_end = ref_subset['end'].max()
+            else:
+                # Create novel isoform ID if no reference matches
+                t_id = f"novel_isoform_{len(enriched_isoforms)}"
+                t_start = group['start'].min()
+                t_end = group['end'].max()
+            
+            enriched_isoforms.append({
+                'transcript_id': t_id, 'chrom': chrom, 'strand': strand,
+                'start': t_start, 'end': t_end, 'introns': introns, 'cluster_id': cluster_id
+            })
+        
+        isoforms_df_final = pd.DataFrame(enriched_isoforms)
+        
+        # Save master TSV for the 'assign' mode
+        out_tsv = f"{args.output_prefix}_enriched.tsv"
+        isoforms_df_final.to_csv(out_tsv, sep='\t', index=False)
+        print(f"[SUCCESS] Enriched TSV saved to {out_tsv}")
+
+        # 5. Generate GTF file
+        gtf_lines = []
+        for _, row in isoforms_df_final.iterrows():
+            attr = f'transcript_id "{row["transcript_id"]}"; gene_id "gene_cluster_{row["cluster_id"]}";'
+            # Transcript row
+            gtf_lines.append([row['chrom'], 'ONT_pipeline', 'transcript', row['start']+1, row['end'], '.', row['strand'], '.', attr])
+            
+            # Exon rows derived from intron structure
+            intron_coords = ast.literal_eval(row['introns'])
+            if not intron_coords:
+                gtf_lines.append([row['chrom'], 'ONT_pipeline', 'exon', row['start']+1, row['end'], '.', row['strand'], '.', attr])
+            else:
+                current_start = row['start']
+                for i_start, i_end in sorted(intron_coords):
+                    gtf_lines.append([row['chrom'], 'ONT_pipeline', 'exon', current_start+1, i_start, '.', row['strand'], '.', attr])
+                    current_start = i_end
+                gtf_lines.append([row['chrom'], 'ONT_pipeline', 'exon', current_start+1, row['end'], '.', row['strand'], '.', attr])
+
+        out_gtf_path = f"{args.output_prefix}_enriched.gtf"
+        pd.DataFrame(gtf_lines).to_csv(out_gtf_path, sep='\t', header=False, index=False, quoting=3)
+        print(f"[SUCCESS] Enriched GTF saved to {out_gtf_path}")
+
+    # --- MODE: ASSIGN ---
     elif args.mode == 'assign':
-        master_map = pd.read_csv(args.input_gtf_file, sep='\t')
-        assignments = pd.merge(read_df, master_map, on=['chrom', 'strand', 'introns'], how='left', suffixes=('', '_ref'))
+        print("[INFO] Loading enriched reference for assignment...")
+        # Note: In assign mode, input_gtf_file should be the .tsv produced by 'enrich'
+        master_ref = pd.read_csv(args.input_gtf_file, sep='\t')
+        isoform_lookup = dict(zip(zip(master_ref.chrom, master_ref.strand, master_ref.introns), master_ref.transcript_id))
         
-        final_cols = ['alignment_id', 'read_id', 'transcript_id', 'chrom', 'start', 'end', 'strand', 'pt', 'qs']
-        
-        # Process Unassigned
-        unassigned = assignments[assignments['transcript_id'].isna()].copy()
-        unassigned_path = f"{args.output_prefix}_unassigned.tsv.gz"
-        unassigned[final_cols].to_csv(unassigned_path, sep='\t', index=False, compression='gzip')
-            
-        # Process Assigned
-        assigned = assignments.dropna(subset=['transcript_id']).copy()
-        out_path = f"{args.output_prefix}_assignments.tsv.gz"
-        assigned[final_cols].to_csv(out_path, sep='\t', index=False, compression='gzip')
-            
-        print(f"[SUCCESS] Assigned: {len(assigned)} | Unassigned: {len(unassigned)}. Saved to {out_path}")
+        assigned_count = 0
+        unassigned_count = 0
+        algn_counter = 0
+
+        out_assigned = f"{args.output_prefix}_assignments.tsv.gz"
+        out_unassigned = f"{args.output_prefix}_unassigned.tsv.gz"
+        header = "alignment_id\tread_id\ttranscript_id\tchrom\tstart\tend\tstrand\tpt\tqs\n"
+
+        with gzip.open(out_assigned, 'wt') as f_assign, gzip.open(out_unassigned, 'wt') as f_unassign:
+            f_assign.write(header)
+            f_unassign.write(header)
+
+            for bam_path in bam_paths:
+                bam_file = HTSeq.SAM_Reader(bam_path)
+                for algn in bam_file:
+                    if not algn.aligned or algn.supplementary:
+                        continue
+                    
+                    try: pt_val = algn.optional_field("pt")
+                    except (KeyError, AttributeError): pt_val = None
+                    try: qs_val = algn.optional_field("qs")
+                    except (KeyError, AttributeError): qs_val = None
+
+                    introns_list = []
+                    if algn.cigar is not None:
+                        for cigar_elem in algn.cigar:
+                            if cigar_elem.type == 'N':
+                                reference_region = cigar_elem.ref_iv
+                                introns_list.append((reference_region.start, reference_region.end + 1))
+                    
+                    introns_str = str(tuple(introns_list))
+                    query_key = (algn.iv.chrom, algn.iv.strand, introns_str)
+                    transcript_id = isoform_lookup.get(query_key, np.nan)
+
+                    row_data = [
+                        str(algn_counter), str(algn.read.name), str(transcript_id),
+                        str(algn.iv.chrom), str(algn.iv.start), str(algn.iv.end),
+                        str(algn.iv.strand), str(pt_val), str(qs_val)
+                    ]
+                    line = "\t".join(row_data) + "\n"
+
+                    if pd.isna(transcript_id):
+                        f_unassign.write(line)
+                        unassigned_count += 1
+                    else:
+                        f_assign.write(line)
+                        assigned_count += 1
+                    
+                    algn_counter += 1
+
+        print(f"[SUCCESS] Assigned: {assigned_count} | Unassigned: {unassigned_count}")
+        print(f"Results saved to: {out_assigned}")
 
 if __name__ == "__main__":
     main()

--- a/bin/assign_ONT_reads_to_isoforms.py
+++ b/bin/assign_ONT_reads_to_isoforms.py
@@ -9,7 +9,15 @@ import numpy as np
 import HTSeq
 import ast
 import gzip
+import logging
 from argparse import ArgumentParser, RawTextHelpFormatter
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s [%(levelname)s] %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S'
+)
 
 def get_introns_from_exons(exons):
     """Converts a list of (start, end) exons to an intron string."""
@@ -44,7 +52,7 @@ def main():
     # --- MODE: ENRICH ---
     if args.mode == 'enrich':
         # 1. Extract Reference Transcriptome Structure
-        print(f"[INFO] Parsing Reference GTF: {args.input_gtf_file}")
+        logging.info(f"Parsing Reference GTF: {args.input_gtf_file}")
         gtf_cols = ['chrom', 'source', 'feature', 'start', 'end', 'score', 'strand', 'frame', 'attribute']
         ref_gtf_full = pd.read_csv(args.input_gtf_file, sep='\t', comment='#', header=None, names=gtf_cols, skiprows=args.gtf_skip_rows)
         
@@ -72,7 +80,7 @@ def main():
         ref_df = pd.DataFrame(ref_data)
 
         # 2. Extract Observed Transcriptome from BAMs
-        print("[INFO] Parsing BAM Alignments...")
+        logging.info("Parsing BAM Alignments...")
         read_coords = []
         algn_counter = 0 
         for bam_path in bam_paths:
@@ -99,7 +107,7 @@ def main():
         read_df = pd.DataFrame(read_coords)
 
         # 3. Merge and Cluster 3' Ends
-        print(f"[INFO] Clustering 3' ends (distance: {args.ThreePrimeEnd_clustering_distance}bp)...")
+        logging.info(f"Clustering 3' ends (distance: {args.ThreePrimeEnd_clustering_distance}bp)...")
         combined_df = pd.concat([ref_df, read_df], ignore_index=True)
         
         # Sort and calculate clusters based on proximity
@@ -137,7 +145,7 @@ def main():
         # Save master TSV for the 'assign' mode
         out_tsv = f"{args.output_prefix}_enriched.tsv"
         isoforms_df_final.to_csv(out_tsv, sep='\t', index=False)
-        print(f"[SUCCESS] Enriched TSV saved to {out_tsv}")
+        logging.info(f"Enriched TSV saved to {out_tsv}")
 
         # 5. Generate GTF file
         gtf_lines = []
@@ -159,11 +167,11 @@ def main():
 
         out_gtf_path = f"{args.output_prefix}_enriched.gtf"
         pd.DataFrame(gtf_lines).to_csv(out_gtf_path, sep='\t', header=False, index=False, quoting=3)
-        print(f"[SUCCESS] Enriched GTF saved to {out_gtf_path}")
+        logging.info(f"Enriched GTF saved to {out_gtf_path}")
 
     # --- MODE: ASSIGN ---
     elif args.mode == 'assign':
-        print("[INFO] Loading enriched reference for assignment...")
+        logging.info("Loading enriched reference for assignment...")
         # Note: In assign mode, input_gtf_file should be the .tsv produced by 'enrich'
         master_ref = pd.read_csv(args.input_gtf_file, sep='\t')
         isoform_lookup = dict(zip(zip(master_ref.chrom, master_ref.strand, master_ref.introns), master_ref.transcript_id))
@@ -218,8 +226,8 @@ def main():
                     
                     algn_counter += 1
 
-        print(f"[SUCCESS] Assigned: {assigned_count} | Unassigned: {unassigned_count}")
-        print(f"Results saved to: {out_assigned}")
+        logging.info(f"Assignment Complete | Assigned: {assigned_count} | Unassigned: {unassigned_count}")
+        logging.info(f"Results saved to: {out_assigned}")
 
 if __name__ == "__main__":
     main()

--- a/bin/assign_ONT_reads_to_isoforms.py
+++ b/bin/assign_ONT_reads_to_isoforms.py
@@ -38,6 +38,7 @@ def main():
             if not algn.aligned or algn.supplementary:
                 continue
             
+            # Extract optional tags pt and qs
             try:
                 pt_val = algn.optional_field("pt")
             except (KeyError, AttributeError):
@@ -94,14 +95,15 @@ def main():
         
         final_cols = ['alignment_id', 'read_id', 'transcript_id', 'chrom', 'start', 'end', 'strand', 'pt', 'qs']
         
-        # Added .copy() to avoid SettingWithCopy warnings
+        # Process Unassigned
         unassigned = assignments[assignments['transcript_id'].isna()].copy()
-        unassigned_path = f"{args.output_prefix}_unassigned.tsv"
-        unassigned[final_cols].to_csv(unassigned_path, sep='\t', index=False)
+        unassigned_path = f"{args.output_prefix}_unassigned.tsv.gz"
+        unassigned[final_cols].to_csv(unassigned_path, sep='\t', index=False, compression='gzip')
             
+        # Process Assigned
         assigned = assignments.dropna(subset=['transcript_id']).copy()
-        out_path = f"{args.output_prefix}_assignments.tsv"
-        assigned[final_cols].to_csv(out_path, sep='\t', index=False)
+        out_path = f"{args.output_prefix}_assignments.tsv.gz"
+        assigned[final_cols].to_csv(out_path, sep='\t', index=False, compression='gzip')
             
         print(f"[SUCCESS] Assigned: {len(assigned)} | Unassigned: {len(unassigned)}. Saved to {out_path}")
 

--- a/bin/assign_ONT_reads_to_isoforms.py
+++ b/bin/assign_ONT_reads_to_isoforms.py
@@ -30,81 +30,78 @@ def main():
 
     # 1. Parse Alignments
     read_coords = []
+    algn_counter = 0 
+
     for bam_path in bam_paths:
-        # Using SAM_Reader as it handles both SAM/BAM correctly in HTSeq and matches the original script
         bam_file = HTSeq.SAM_Reader(bam_path)
         for algn in bam_file:
             if not algn.aligned or algn.supplementary:
                 continue
             
+            try:
+                pt_val = algn.optional_field("pt")
+            except (KeyError, AttributeError):
+                pt_val = None
+                
+            try:
+                qs_val = algn.optional_field("qs")
+            except (KeyError, AttributeError):
+                qs_val = None
+            
             introns_list = []
             cigar_string = ""
             
-            # Explicitly parse the CIGAR string to find splice junctions ('N')
             if algn.cigar is not None:
                 for cigar_elem in algn.cigar:
                     cigar_string += f"{cigar_elem.size}{cigar_elem.type}"
                     if cigar_elem.type == 'N': 
                         reference_region = cigar_elem.ref_iv
-                        # 1-based end coordinate matching original script logic
                         introns_list.append((reference_region.start, reference_region.end + 1))
             
-            # Convert to string so pandas can group by it later
             introns_str = str(tuple(introns_list))
             
-            # Unique ID: read_id + region + CIGAR string
-            uid = f"{algn.read.name}_{algn.iv.chrom}_{algn.iv.start}_{algn.iv.end}_{cigar_string}"
-            
             read_coords.append({
+                'alignment_id': algn_counter, 
                 'read_id': algn.read.name,
-                'alignment_id': uid,
                 'chrom': algn.iv.chrom,
                 'start': algn.iv.start,
                 'end': algn.iv.end,
                 'strand': algn.iv.strand,
-                'introns': introns_str
+                'introns': introns_str,
+                'pt': pt_val,
+                'qs': qs_val
             })
+            algn_counter += 1
     
     read_df = pd.DataFrame(read_coords)
 
-    # Safety check for empty dataframes
     if read_df.empty:
         print("[WARNING] No valid alignments found in the provided BAM file(s).")
         sys.exit(0)
 
     # 2. Process based on Mode
     if args.mode == 'enrich':
-        # Group identical read structures into unique master isoforms
         isoforms_df = read_df.groupby(['chrom', 'strand', 'introns']).agg({'start': 'min', 'end': 'max'}).reset_index()
         isoforms_df['transcript_id'] = [f"isoform_{i}" for i in range(len(isoforms_df))]
         
-        # Save Enriched Transcriptome
         out_path = f"{args.output_prefix}_enriched.tsv"
         isoforms_df.to_csv(out_path, sep='\t', index=False)
         print(f"[SUCCESS] Enriched transcriptome saved to {out_path} with {len(isoforms_df)} unique isoforms.")
 
     elif args.mode == 'assign':
-        # Load the Master Map created in 'enrich' mode
         master_map = pd.read_csv(args.input_gtf_file, sep='\t')
-        
-        # Map reads to Master Map IDs
         assignments = pd.merge(read_df, master_map, on=['chrom', 'strand', 'introns'], how='left', suffixes=('', '_ref'))
         
-        # Format output as requested: Associate every alignment with ONE transcript_id
-        final_cols = ['alignment_id', 'read_id', 'transcript_id', 'chrom', 'start', 'end', 'strand']
-        out_path = f"{args.output_prefix}_assignments.tsv"
+        final_cols = ['alignment_id', 'read_id', 'transcript_id', 'chrom', 'start', 'end', 'strand', 'pt', 'qs']
         
-        # Handle unassigned reads
-        unassigned = assignments[assignments['transcript_id'].isna()]
-        if not unassigned.empty:
-            unassigned[final_cols].to_csv(f"{args.output_prefix}_unassigned.tsv", sep='\t', index=False)
+        # Added .copy() to avoid SettingWithCopy warnings
+        unassigned = assignments[assignments['transcript_id'].isna()].copy()
+        unassigned_path = f"{args.output_prefix}_unassigned.tsv"
+        unassigned[final_cols].to_csv(unassigned_path, sep='\t', index=False)
             
-        assigned = assignments.dropna(subset=['transcript_id'])
-        if not assigned.empty:
-            assigned[final_cols].to_csv(out_path, sep='\t', index=False)
-        else:
-            # Output an empty file with headers if no assignments match
-            pd.DataFrame(columns=final_cols).to_csv(out_path, sep='\t', index=False)
+        assigned = assignments.dropna(subset=['transcript_id']).copy()
+        out_path = f"{args.output_prefix}_assignments.tsv"
+        assigned[final_cols].to_csv(out_path, sep='\t', index=False)
             
         print(f"[SUCCESS] Assigned: {len(assigned)} | Unassigned: {len(unassigned)}. Saved to {out_path}")
 

--- a/main.nf
+++ b/main.nf
@@ -44,7 +44,7 @@ workflow {
     // B. Assign individual alignments for each sample to the enriched transcriptome
     read_to_transcript_assignment(
         merge_bams.out.bam, 
-        transcriptome_annotation_enrichment.out.gtf
+        transcriptome_annotation_enrichment.out.tsv
     )
 
     // ==============================================================================
@@ -128,7 +128,8 @@ process transcriptome_annotation_enrichment {
     path reference_gtf
 
     output:
-    path "master_enriched.tsv", emit: gtf
+    path "master_enriched.tsv", emit: tsv
+    path "master_enriched.gtf", emit: gtf
 
     script:
     """
@@ -149,21 +150,19 @@ process read_to_transcript_assignment {
 
     input:
     tuple val(sample_id), path(bam)
-    path enriched_gtf
+    path enriched_tsv
 
     output:
     tuple val(sample_id), path("${sample_id}_assignments.tsv.gz"), emit: tsv
-    path "${sample_id}_unassigned.tsv", optional: true
+    path "${sample_id}_unassigned.tsv.gz", optional: true
 
     script:
     """
     assign_ONT_reads_to_isoforms.py \\
         --mode assign \\
         --input_bam_files ${bam} \\
-        --input_gtf_file ${enriched_gtf} \\
-        --output_prefix ${sample_id}
-    
-    gzip ${sample_id}_assignments.tsv
+        --input_gtf_file ${enriched_tsv} \\
+        --output_prefix ${sample_id}    
     """
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -26,7 +26,7 @@ params {
     //  SOFTWARE & ENVIRONMENT PATHS
     // ---------------------------------------------------------------------------------
     // dorado: Path to the Dorado basecaller executable
-    dorado     = "${myHome}/dorado-1.3.1-linux-x64/bin/dorado"
+    dorado     = "${myHome}/dorado-1.4.0-linux-x64/bin/dorado"
     // condaEnv: Path to the pre-configured Conda environment for Python dependencies
     condaEnv   = "${myHome}/miniconda3/envs/nanopore"
 


### PR DESCRIPTION
Why:
Downstream ONT isoform analyses often need alignment-level metadata (e.g. optional BAM tags) for quality filtering and troubleshooting. The isoform assignment outputs previously omitted these tags, and the alignment identifier was derived from a composite string that could vary with representation details.

What:
- bin/assign_ONT_reads_to_isoforms.py
  - Extract optional BAM fields `pt` and `qs` (when present) and add them to the per-alignment records.
  - Include `pt` and `qs` columns in both:
    - *_assignments.tsv
    - *_unassigned.tsv
  - Change `alignment_id` generation from a derived UID (read/coordinates/CIGAR-based) to a deterministic sequential counter.
  - Use `.copy()` on filtered `assigned`/`unassigned` dataframes to avoid pandas SettingWithCopy issues and keep output writing consistent.
- nextflow.config
  - Bump Dorado basecaller from `dorado-1.3.1-linux-x64` to `dorado-1.4.0-linux-x64` by updating the `params.dorado` path.

Impact / notes:
- Output schema changes: `*_assignments.tsv` and `*_unassigned.tsv` now include `pt` and `qs`.
- `alignment_id` format changes (from composite UID to sequential id), so any downstream consumer relying on the old identifier pattern should be updated.