### PR TITLE
fix: add resource limits for merge_bams to prevent truncated BAMs

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -80,6 +80,12 @@ process {
     //  GPU RESOURCE OVERRIDES (DORADO TASKS)
     //  Dorado requires a GPU; settings below target a single A100 per job.
     // ---------------------------------------------------------------------------------
+    withName: merge_bams {
+        cpus   = 8
+        memory = '16 GB'
+        time   = '2h'
+    }
+
     withName: 'dorado_basecall|dorado_emit_moves' {
         queue          = 'a100'
         cpus           = 6


### PR DESCRIPTION
Default 4 GB / 20 min limits caused samtools merge to be killed by SLURM before writing the EOF block, producing corrupted BAM files.